### PR TITLE
fix: what is MARKUP? Update posts.md

### DIFF
--- a/docs/_docs/posts.md
+++ b/docs/_docs/posts.md
@@ -20,17 +20,19 @@ To create a post, add a file to your `_posts` directory with the following
 format:
 
 ```
-YEAR-MONTH-DAY-title.MARKUP
+YEAR-MONTH-DAY-title.markdown
 ```
 
 Where `YEAR` is a four-digit number, `MONTH` and `DAY` are both two-digit
-numbers, and `MARKUP` is the file extension representing the format used in the
+numbers, and `markdown` is the file extension representing the format used in the
 file. For example, the following are examples of valid post filenames:
 
 ```
 2011-12-31-new-years-eve-is-awesome.md
 2012-09-12-how-to-write-a-blog.md
 ```
+
+Jekyll supports both `md` and `markdown` file extensions.
 
 All blog post files must begin with [front matter](/docs/front-matter/) which is
 typically used to set a [layout](/docs/layouts/) or other meta data. For a simple
@@ -69,6 +71,8 @@ I hope you like it!
     <code>&lt;head&gt;</code> of your layout.
   </p>
 </div>
+
+## How filename and post title 
 
 ## Including images and resources
 


### PR DESCRIPTION
google search eluded me. I'm pretty sure this is a typo. I tried creating a .markup file on my local and it doesn't render markdown -> html as I would expect.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
This is a 🔦 documentation change.
<!-- This is a 🔨 code refactoring. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

Fixes (?) I think the file extension types in the post.md documentation and indicates that both `md` and `markdown` are valid extensions

## Context

no
